### PR TITLE
Vitor/gle 15 parse fen into board

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: test
+
+on:
+  push:
+    branches:
+      - master
+      - main
+      - dev
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "27.1.2"
+          gleam-version: "1.9.1"
+          rebar3-version: "3"
+          # elixir-version: "1"
+      - run: gleam deps download
+      - run: gleam test
+      - run: gleam format --check src test

--- a/src/chess_bot/board.gleam
+++ b/src/chess_bot/board.gleam
@@ -1,11 +1,40 @@
 import chess_bot/piece
+import gleam/int
+import gleam/list
 import gleam/option
+import gleam/result
+import gleam/string
 import glearray
 
 pub const size = 8
 
 pub type Board =
-  glearray.Array(String)
+  glearray.Array(Square)
 
 pub type Square =
   option.Option(piece.Piece)
+
+pub fn from_fen(fen_board) {
+  let board = glearray.new()
+
+  string.replace(fen_board, "/", "")
+  |> string.split("")
+  |> list.try_fold(board, fen_char_to_square)
+}
+
+fn fen_char_to_square(board, fen_char) {
+  result.map(int.parse(fen_char), fn(number) {
+    push_num(board, option.None, number)
+  })
+  |> result.try_recover(fn(_) {
+    piece.fen_char_to_piece(fen_char)
+    |> result.map(fn(piece) { glearray.copy_push(board, option.Some(piece)) })
+  })
+}
+
+pub fn push_num(array, item, number) {
+  case number {
+    0 -> array
+    _ -> glearray.copy_push(array, item) |> push_num(item, number - 1)
+  }
+}

--- a/src/chess_bot/board.gleam
+++ b/src/chess_bot/board.gleam
@@ -8,6 +8,15 @@ import glearray
 
 pub const size = 8
 
+pub type ParseError {
+  InvalidFile(String)
+  InvalidRankChar(String)
+  InvalidRankInt(Int)
+  InvalidAlgebraicCoordinate(String)
+  NotInt(String)
+  InsertBoardError(index: Int)
+}
+
 pub type Board =
   glearray.Array(Square)
 
@@ -37,4 +46,61 @@ pub fn push_num(array, item, number) {
     0 -> array
     _ -> glearray.copy_push(array, item) |> push_num(item, number - 1)
   }
+}
+
+pub fn file_to_int(file_char) {
+  case file_char {
+    "a" -> Ok(0)
+    "b" -> Ok(1)
+    "c" -> Ok(2)
+    "d" -> Ok(3)
+    "e" -> Ok(4)
+    "f" -> Ok(5)
+    "g" -> Ok(6)
+    "h" -> Ok(7)
+    invalid -> Error(InvalidFile(invalid))
+  }
+}
+
+/// chess notation is 1 indexed, this converts
+/// to 0 index and also from a char
+pub fn rank_char_to_int(rank_char) {
+  use val <- result.map(
+    int.parse(rank_char)
+    |> result.replace_error(NotInt(rank_char)),
+  )
+
+  val - 1
+}
+
+pub fn rank_int_to_int(rank_int) {
+  case rank_int < 9 && rank_int != 0 {
+    True -> Ok(rank_int - 1)
+    False -> Error(InvalidRankInt(rank_int))
+  }
+}
+
+/// coordinate is a 2 char string such as "e2", "h8"
+pub fn set_piece_at_algebraic_coordinate(board, piece, coordinate) {
+  let coordinate_result = case string.length(coordinate) {
+    2 -> Ok(coordinate)
+    _ -> Error(InvalidAlgebraicCoordinate(coordinate))
+  }
+
+  use coordinate <- result.try(coordinate_result)
+  let assert [file_char, rank_char] = string.split(coordinate, "")
+
+  use file <- result.try(file_to_int(file_char))
+  use rank <- result.try(rank_char_to_int(rank_char))
+  let index = file + 8 * rank
+
+  use board <- result.map(
+    glearray.copy_set(board, index, piece)
+    |> result.replace_error(InsertBoardError(index)),
+  )
+  board
+}
+
+pub fn make_empty_board() {
+  glearray.new() |> push_num(option.None, 64)
 }

--- a/src/chess_bot/board.gleam
+++ b/src/chess_bot/board.gleam
@@ -28,13 +28,11 @@ pub fn from_fen(fen_board) {
 
   string.replace(fen_board, "/", "")
   |> string.split("")
-  |> list.try_fold(board, fen_char_to_square)
+  |> list.try_fold(board, fen_char_to_board)
 }
 
-fn fen_char_to_square(board, fen_char) {
-  result.map(int.parse(fen_char), fn(number) {
-    push_num(board, option.None, number)
-  })
+fn fen_char_to_board(board, fen_char) {
+  result.map(int.parse(fen_char), push_num(board, option.None, _))
   |> result.try_recover(fn(_) {
     piece.fen_char_to_piece(fen_char)
     |> result.map(fn(piece) { glearray.copy_push(board, option.Some(piece)) })
@@ -65,12 +63,9 @@ pub fn file_to_int(file_char) {
 /// chess notation is 1 indexed, this converts
 /// to 0 index and also from a char
 pub fn rank_char_to_int(rank_char) {
-  use val <- result.try(
-    int.parse(rank_char)
-    |> result.replace_error(NotInt(rank_char)),
-  )
-
-  rank_int_to_int(val)
+  int.parse(rank_char)
+  |> result.replace_error(NotInt(rank_char))
+  |> result.try(rank_int_to_int)
 }
 
 pub fn rank_int_to_int(rank_int) {
@@ -82,23 +77,18 @@ pub fn rank_int_to_int(rank_int) {
 
 /// coordinate is a 2 char string such as "e2", "h8"
 pub fn set_piece_at_algebraic_coordinate(board, piece, coordinate) {
-  let coordinate_result = case string.length(coordinate) {
-    2 -> Ok(coordinate)
+  let coordinate_result = case string.split(coordinate, "") {
+    [file_char, rank_char] -> Ok(#(file_char, rank_char))
     _ -> Error(InvalidAlgebraicCoordinate(coordinate))
   }
-
-  use coordinate <- result.try(coordinate_result)
-  let assert [file_char, rank_char] = string.split(coordinate, "")
+  use #(file_char, rank_char) <- result.try(coordinate_result)
 
   use file <- result.try(file_to_int(file_char))
   use rank <- result.try(rank_char_to_int(rank_char))
   let index = file + 8 * rank
 
-  use board <- result.map(
-    glearray.copy_set(board, index, piece)
-    |> result.replace_error(InsertBoardError(index)),
-  )
-  board
+  glearray.copy_set(board, index, piece)
+  |> result.replace_error(InsertBoardError(index))
 }
 
 pub fn make_empty_board() {

--- a/src/chess_bot/board.gleam
+++ b/src/chess_bot/board.gleam
@@ -65,12 +65,12 @@ pub fn file_to_int(file_char) {
 /// chess notation is 1 indexed, this converts
 /// to 0 index and also from a char
 pub fn rank_char_to_int(rank_char) {
-  use val <- result.map(
+  use val <- result.try(
     int.parse(rank_char)
     |> result.replace_error(NotInt(rank_char)),
   )
 
-  val - 1
+  rank_int_to_int(val)
 }
 
 pub fn rank_int_to_int(rank_int) {

--- a/src/chess_bot/game.gleam
+++ b/src/chess_bot/game.gleam
@@ -7,6 +7,7 @@ import gleam/string
 
 pub type ParseError {
   InvalidColour
+  InvalidFenString
   Piece(piece.ParseError)
   NotInt(String)
 }
@@ -51,27 +52,32 @@ pub fn set_moves(game, moves) {
 }
 
 pub fn from_fen(fen) {
-  let assert [
-    fen_board,
-    fen_to_move,
-    fen_castle,
-    fen_en_passant,
-    fen_half_move,
-    fen_moves,
-  ] = string.split(fen, " ")
+  case string.split(fen, " ") {
+    [
+      fen_board,
+      fen_to_move,
+      fen_castle,
+      fen_en_passant,
+      fen_half_move,
+      fen_moves,
+    ] -> {
+      use board <- result.try(
+        board.from_fen(fen_board) |> result.map_error(Piece),
+      )
+      use colour_to_move <- result.try(from_fen_to_move(fen_to_move))
+      let castle = dash_to_none(fen_castle)
+      let en_passant = dash_to_none(fen_en_passant)
+      use half_moves <- result.try(
+        int.parse(fen_half_move) |> result.replace_error(NotInt(fen_half_move)),
+      )
+      use moves <- result.map(
+        int.parse(fen_moves) |> result.replace_error(NotInt(fen_moves)),
+      )
 
-  use board <- result.try(board.from_fen(fen_board) |> result.map_error(Piece))
-  use colour <- result.try(from_fen_to_move(fen_to_move))
-  let castle = dash_to_none(fen_castle)
-  let en_passant = dash_to_none(fen_en_passant)
-  use half_moves <- result.try(
-    int.parse(fen_half_move) |> result.replace_error(NotInt(fen_half_move)),
-  )
-  use moves <- result.try(
-    int.parse(fen_moves) |> result.replace_error(NotInt(fen_moves)),
-  )
-
-  Ok(Model(colour, board, castle, en_passant, half_moves, moves))
+      Model(colour_to_move:, board:, castle:, en_passant:, half_moves:, moves:)
+    }
+    _otherwise -> Error(InvalidFenString)
+  }
 }
 
 fn dash_to_none(dash_or_string) {

--- a/src/chess_bot/game.gleam
+++ b/src/chess_bot/game.gleam
@@ -1,0 +1,60 @@
+import chess_bot/board
+import chess_bot/piece
+import gleam/int
+import gleam/option.{type Option}
+import gleam/result
+import gleam/string
+
+pub type ParseError {
+  InvalidColor
+  Piece(piece.ParseError)
+  NotInt
+}
+
+pub type Game {
+  Model(
+    color_to_move: piece.Colour,
+    board: board.Board,
+    en_passant: Option(String),
+    castle: Option(String),
+    half_moves: Int,
+    moves: Int,
+  )
+}
+
+pub fn from_fen(fen) {
+  let assert [
+    fen_board,
+    fen_to_move,
+    fen_castle,
+    fen_en_passant,
+    fen_half_move,
+    fen_moves,
+  ] = string.split(fen, " ")
+
+  use board <- result.try(board.from_fen(fen_board) |> result.map_error(Piece))
+  use color <- result.try(from_fen_to_move(fen_to_move))
+  let castle = dash_to_none(fen_castle)
+  let en_passant = dash_to_none(fen_en_passant)
+  use half_moves <- result.try(
+    int.parse(fen_half_move) |> result.replace_error(NotInt),
+  )
+  use moves <- result.try(int.parse(fen_moves) |> result.replace_error(NotInt))
+
+  Ok(Model(color, board, castle, en_passant, half_moves, moves))
+}
+
+fn dash_to_none(dash_or_string) {
+  case dash_or_string {
+    "-" -> option.None
+    otherwise -> option.Some(otherwise)
+  }
+}
+
+fn from_fen_to_move(fen_move) {
+  case fen_move {
+    "w" -> Ok(piece.White)
+    "b" -> Ok(piece.Black)
+    _ -> Error(InvalidColor)
+  }
+}

--- a/src/chess_bot/game.gleam
+++ b/src/chess_bot/game.gleam
@@ -6,20 +6,48 @@ import gleam/result
 import gleam/string
 
 pub type ParseError {
-  InvalidColor
+  InvalidColour
   Piece(piece.ParseError)
   NotInt(String)
 }
 
 pub type Game {
   Model(
-    color_to_move: piece.Colour,
+    colour_to_move: piece.Colour,
     board: board.Board,
     en_passant: Option(String),
     castle: Option(String),
     half_moves: Int,
     moves: Int,
   )
+}
+
+pub fn empty_game() {
+  Model(piece.White, board.make_empty_board(), option.None, option.None, 0, 1)
+}
+
+pub fn set_colour(game, colour) {
+  Model(..game, colour_to_move: colour)
+}
+
+pub fn set_board(game, board) {
+  Model(..game, board:)
+}
+
+pub fn set_en_passant(game, en_passant) {
+  Model(..game, en_passant:)
+}
+
+pub fn set_castle(game, castle) {
+  Model(..game, castle:)
+}
+
+pub fn set_half_moves(game, half_moves) {
+  Model(..game, half_moves:)
+}
+
+pub fn set_moves(game, moves) {
+  Model(..game, moves:)
 }
 
 pub fn from_fen(fen) {
@@ -33,7 +61,7 @@ pub fn from_fen(fen) {
   ] = string.split(fen, " ")
 
   use board <- result.try(board.from_fen(fen_board) |> result.map_error(Piece))
-  use color <- result.try(from_fen_to_move(fen_to_move))
+  use colour <- result.try(from_fen_to_move(fen_to_move))
   let castle = dash_to_none(fen_castle)
   let en_passant = dash_to_none(fen_en_passant)
   use half_moves <- result.try(
@@ -43,7 +71,7 @@ pub fn from_fen(fen) {
     int.parse(fen_moves) |> result.replace_error(NotInt(fen_moves)),
   )
 
-  Ok(Model(color, board, castle, en_passant, half_moves, moves))
+  Ok(Model(colour, board, castle, en_passant, half_moves, moves))
 }
 
 fn dash_to_none(dash_or_string) {
@@ -57,6 +85,6 @@ fn from_fen_to_move(fen_move) {
   case fen_move {
     "w" -> Ok(piece.White)
     "b" -> Ok(piece.Black)
-    _ -> Error(InvalidColor)
+    _ -> Error(InvalidColour)
   }
 }

--- a/src/chess_bot/game.gleam
+++ b/src/chess_bot/game.gleam
@@ -8,7 +8,7 @@ import gleam/string
 pub type ParseError {
   InvalidColor
   Piece(piece.ParseError)
-  NotInt
+  NotInt(String)
 }
 
 pub type Game {
@@ -37,9 +37,11 @@ pub fn from_fen(fen) {
   let castle = dash_to_none(fen_castle)
   let en_passant = dash_to_none(fen_en_passant)
   use half_moves <- result.try(
-    int.parse(fen_half_move) |> result.replace_error(NotInt),
+    int.parse(fen_half_move) |> result.replace_error(NotInt(fen_half_move)),
   )
-  use moves <- result.try(int.parse(fen_moves) |> result.replace_error(NotInt))
+  use moves <- result.try(
+    int.parse(fen_moves) |> result.replace_error(NotInt(fen_moves)),
+  )
 
   Ok(Model(color, board, castle, en_passant, half_moves, moves))
 }

--- a/src/chess_bot/piece.gleam
+++ b/src/chess_bot/piece.gleam
@@ -15,3 +15,25 @@ pub type Kind {
   Rook
   Pawn
 }
+
+pub type ParseError {
+  InvalidPiece(String)
+}
+
+pub fn fen_char_to_piece(fen_char) {
+  case fen_char {
+    "K" -> Ok(Piece(White, King))
+    "Q" -> Ok(Piece(White, Queen))
+    "B" -> Ok(Piece(White, Bishop))
+    "N" -> Ok(Piece(White, Knight))
+    "R" -> Ok(Piece(White, Rook))
+    "P" -> Ok(Piece(White, Pawn))
+    "k" -> Ok(Piece(Black, King))
+    "q" -> Ok(Piece(Black, Queen))
+    "b" -> Ok(Piece(Black, Bishop))
+    "n" -> Ok(Piece(Black, Knight))
+    "r" -> Ok(Piece(Black, Rook))
+    "p" -> Ok(Piece(Black, Pawn))
+    _otherwise -> Error(InvalidPiece(fen_char))
+  }
+}

--- a/src/chess_bot/piece.gleam
+++ b/src/chess_bot/piece.gleam
@@ -1,3 +1,5 @@
+import gleam/option
+
 pub type Piece {
   Piece(colour: Colour, kind: Kind)
 }
@@ -18,6 +20,10 @@ pub type Kind {
 
 pub type ParseError {
   InvalidPiece(String)
+}
+
+pub fn get_piece(colour, kind) {
+  option.Some(Piece(colour, kind))
 }
 
 pub fn fen_char_to_piece(fen_char) {

--- a/test/board_parsing_test.gleam
+++ b/test/board_parsing_test.gleam
@@ -1,0 +1,104 @@
+import chess_bot/board
+import chess_bot/game
+import chess_bot/piece
+import gleam/option
+import glearray
+import gleeunit/should
+
+pub fn parse_empty_game_board_test() {
+  let empty_board = glearray.new() |> board.push_num(option.None, 64)
+
+  game.from_fen("8/8/8/8/8/8/8/8 w - - 0 1")
+  |> should.equal(
+    Ok(game.Model(piece.White, empty_board, option.None, option.None, 0, 1)),
+  )
+}
+
+pub fn parse_pieces_test() {
+  let board_with_white_pawn =
+    glearray.new()
+    |> glearray.copy_push(option.Some(piece.Piece(piece.White, piece.Pawn)))
+    |> board.push_num(option.None, 63)
+
+  game.from_fen("P7/8/8/8/8/8/8/8 w - - 0 1")
+  |> should.equal(
+    Ok(game.Model(
+      piece.White,
+      board_with_white_pawn,
+      option.None,
+      option.None,
+      0,
+      1,
+    )),
+  )
+
+  let board_with_black_pawn =
+    glearray.new()
+    |> glearray.copy_push(option.Some(piece.Piece(piece.Black, piece.Pawn)))
+    |> board.push_num(option.None, 63)
+
+  game.from_fen("p7/8/8/8/8/8/8/8 w - - 0 1")
+  |> should.equal(
+    Ok(game.Model(
+      piece.White,
+      board_with_black_pawn,
+      option.None,
+      option.None,
+      0,
+      1,
+    )),
+  )
+
+  game.from_fen("8/8/8/8/8/8/8/8 w - - 0 1")
+  |> should.not_equal(
+    Ok(game.Model(
+      piece.White,
+      board_with_black_pawn,
+      option.None,
+      option.None,
+      0,
+      1,
+    )),
+  )
+}
+
+pub fn parse_color_test() {
+  let empty_board = glearray.new() |> board.push_num(option.None, 64)
+
+  game.from_fen("8/8/8/8/8/8/8/8 b - - 0 1")
+  |> should.equal(
+    Ok(game.Model(piece.Black, empty_board, option.None, option.None, 0, 1)),
+  )
+}
+
+pub fn parse_castle_test() {
+  let empty_board = glearray.new() |> board.push_num(option.None, 64)
+
+  game.from_fen("8/8/8/8/8/8/8/8 b KQkq - 0 1")
+  |> should.equal(
+    Ok(game.Model(
+      piece.Black,
+      empty_board,
+      option.Some("KQkq"),
+      option.None,
+      0,
+      1,
+    )),
+  )
+}
+
+pub fn parse_en_passant_test() {
+  let empty_board = glearray.new() |> board.push_num(option.None, 64)
+
+  game.from_fen("8/8/8/8/8/8/8/8 b - c6 0 1")
+  |> should.equal(
+    Ok(game.Model(
+      piece.Black,
+      empty_board,
+      option.None,
+      option.Some("c6"),
+      0,
+      1,
+    )),
+  )
+}

--- a/test/board_parsing_test.gleam
+++ b/test/board_parsing_test.gleam
@@ -6,12 +6,39 @@ import glearray
 import gleeunit/should
 
 pub fn parse_empty_game_board_test() {
-  let empty_board = glearray.new() |> board.push_num(option.None, 64)
+  let empty_board = board.make_empty_board()
 
   game.from_fen("8/8/8/8/8/8/8/8 w - - 0 1")
   |> should.equal(
     Ok(game.Model(piece.White, empty_board, option.None, option.None, 0, 1)),
   )
+}
+
+pub fn insert_piece_test() {
+  let empty_board = board.make_empty_board()
+  let assert Ok(board_with_c6_queen) =
+    board.set_piece_at_algebraic_coordinate(
+      empty_board,
+      piece.get_piece(piece.White, piece.Queen),
+      "c6",
+    )
+
+  let assert Ok(board_with_c6_queen_from_fen) =
+    game.from_fen("8/8/8/8/8/2Q5/8/8 w - - 0 1")
+
+  glearray.length(board_with_c6_queen_from_fen.board) |> should.equal(64)
+
+  glearray.length(board_with_c6_queen) |> should.equal(64)
+
+  board_with_c6_queen_from_fen
+  |> should.equal(game.Model(
+    piece.White,
+    board_with_c6_queen,
+    option.None,
+    option.None,
+    0,
+    1,
+  ))
 }
 
 pub fn parse_pieces_test() {
@@ -63,7 +90,7 @@ pub fn parse_pieces_test() {
 }
 
 pub fn parse_color_test() {
-  let empty_board = glearray.new() |> board.push_num(option.None, 64)
+  let empty_board = board.make_empty_board()
 
   game.from_fen("8/8/8/8/8/8/8/8 b - - 0 1")
   |> should.equal(
@@ -72,7 +99,7 @@ pub fn parse_color_test() {
 }
 
 pub fn parse_castle_test() {
-  let empty_board = glearray.new() |> board.push_num(option.None, 64)
+  let empty_board = board.make_empty_board()
 
   game.from_fen("8/8/8/8/8/8/8/8 b KQkq - 0 1")
   |> should.equal(

--- a/test/board_parsing_test.gleam
+++ b/test/board_parsing_test.gleam
@@ -89,7 +89,7 @@ pub fn parse_pieces_test() {
   )
 }
 
-pub fn parse_color_test() {
+pub fn parse_colour_test() {
   let empty_board = board.make_empty_board()
 
   game.from_fen("8/8/8/8/8/8/8/8 b - - 0 1")

--- a/test/board_parsing_test.gleam
+++ b/test/board_parsing_test.gleam
@@ -99,33 +99,18 @@ pub fn parse_colour_test() {
 }
 
 pub fn parse_castle_test() {
-  let empty_board = board.make_empty_board()
-
-  game.from_fen("8/8/8/8/8/8/8/8 b KQkq - 0 1")
-  |> should.equal(
-    Ok(game.Model(
-      piece.Black,
-      empty_board,
-      option.Some("KQkq"),
-      option.None,
-      0,
-      1,
-    )),
-  )
+  game.from_fen("8/8/8/8/8/8/8/8 w KQkq - 0 1")
+  |> should.equal(Ok(
+    game.empty_game()
+    |> game.set_castle(option.Some("KQkq")),
+  ))
 }
 
 pub fn parse_en_passant_test() {
-  let empty_board = glearray.new() |> board.push_num(option.None, 64)
-
   game.from_fen("8/8/8/8/8/8/8/8 b - c6 0 1")
-  |> should.equal(
-    Ok(game.Model(
-      piece.Black,
-      empty_board,
-      option.None,
-      option.Some("c6"),
-      0,
-      1,
-    )),
-  )
+  |> should.equal(Ok(
+    game.empty_game()
+    |> game.set_colour(piece.Black)
+    |> game.set_en_passant(option.Some("c6")),
+  ))
 }

--- a/test/chess_bot_test.gleam
+++ b/test/chess_bot_test.gleam
@@ -1,12 +1,5 @@
 import gleeunit
-import gleeunit/should
 
 pub fn main() {
   gleeunit.main()
-}
-
-// gleeunit test functions end in `_test`
-pub fn hello_world_test() {
-  1
-  |> should.equal(1)
 }


### PR DESCRIPTION
Fixes GLE-16, GLE-15, GLE-10

^ this links to Linear through the issue number btw

Adds defs for board, game

Parsing functions and related helpers for parsing from fen to a game

many helpers added after so tests are a bit ugly, can refactor later

Also assume we want to 0 index the board since algebraic notation is 1 indexed

We'll also want to refactor the en_passant, castling into proper type defs instead of strings, trying to avoid over abstracting for now